### PR TITLE
Fix inappropriate error shown in the log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/benweissmann/memongo
 
+go 1.14
+
 require (
 	github.com/acobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249
 	github.com/go-stack/stack v1.8.0 // indirect

--- a/mongobin/getOrDownload.go
+++ b/mongobin/getOrDownload.go
@@ -130,7 +130,7 @@ func GetOrDownloadMongod(urlStr string, cachePath string, logger *memongolog.Log
 
 	renameErr := afs.Rename(mongodTmpFile.Name(), mongodPath)
 	if renameErr != nil {
-		return "", fmt.Errorf("error writing mongod binary from %s to %s: %s", mongodTmpFile.Name(), mongodPath, writeErr)
+		return "", fmt.Errorf("error writing mongod binary from %s to %s: %s", mongodTmpFile.Name(), mongodPath, renameErr)
 	}
 
 	logger.Infof("finished downloading mongod to %s in %s", mongodPath, time.Since(downloadStartTime).String())


### PR DESCRIPTION
The inappropriate error variable was shown in the log. This can be reflected by running the `go test` for this package. Believe that this is a typo.