### PR TITLE
Fix inappropriate error shown in the log

### DIFF
--- a/mongobin/getOrDownload.go
+++ b/mongobin/getOrDownload.go
@@ -130,7 +130,7 @@ func GetOrDownloadMongod(urlStr string, cachePath string, logger *memongolog.Log
 
 	renameErr := afs.Rename(mongodTmpFile.Name(), mongodPath)
 	if renameErr != nil {
-		return "", fmt.Errorf("error writing mongod binary from %s to %s: %s", mongodTmpFile.Name(), mongodPath, writeErr)
+		return "", fmt.Errorf("error writing mongod binary from %s to %s: %s", mongodTmpFile.Name(), mongodPath, renameErr)
 	}
 
 	logger.Infof("finished downloading mongod to %s in %s", mongodPath, time.Since(downloadStartTime).String())


### PR DESCRIPTION
The inappropriate error variable was shown in the log. This can be reflected by running the go test for this package. Believe that this is a typo.