### PR TITLE
Updated regex for getting port

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,6 @@
-module github.com/benweissmann/memongo
+module github.com/sbansal7/memongo
+
+go 1.15
 
 require (
 	github.com/acobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249

--- a/main.go
+++ b/main.go
@@ -185,7 +185,7 @@ func (s *Server) Stop() {
 }
 
 // Cribbed from https://github.com/nodkz/mongodb-memory-server/blob/master/packages/mongodb-memory-server-core/src/util/MongoInstance.ts#L206
-var reReady = regexp.MustCompile(`waiting for connections on port (\d+)`)
+var reReady = regexp.MustCompile(`waiting for connections.*port\D*(\d+)`)
 var reAlreadyInUse = regexp.MustCompile("addr already in use")
 var reAlreadyRunning = regexp.MustCompile("mongod already running")
 var rePermissionDenied = regexp.MustCompile("mongod permission denied")


### PR DESCRIPTION
New version of mongo shows it differently:
`{"t":{"$date":"2021-04-20T17:28:20.364-07:00"},"s":"I",  "c":"NETWORK",  "id":23016,   "ctx":"listener","msg":"Waiting for connections","attr":{"port":59432,"ssl":"off"}}`